### PR TITLE
Hotfix for SystemBuilder due to parameter missmatch

### DIFF
--- a/SharperUniverse.Tests/Stubs/BarSystem.cs
+++ b/SharperUniverse.Tests/Stubs/BarSystem.cs
@@ -8,7 +8,7 @@ namespace SharperUniverse.Tests.Stubs
     {
         public bool TestSwitch { get; set; }
 
-        public BarSystem(GameRunner game) : base(game)
+        public BarSystem(IGameRunner game) : base(game)
         {
             TestSwitch = false;
         }

--- a/SharperUniverse.Tests/Stubs/EmptySystem.cs
+++ b/SharperUniverse.Tests/Stubs/EmptySystem.cs
@@ -8,7 +8,7 @@ namespace SharperUniverse.Tests.Stubs
     {
         public bool TestSwitch { get; set; }
 
-        public EmptySystem(GameRunner game) : base(game)
+        public EmptySystem(IGameRunner game) : base(game)
         {
             TestSwitch = false;
         }

--- a/SharperUniverse.Tests/Stubs/FooBarSystem.cs
+++ b/SharperUniverse.Tests/Stubs/FooBarSystem.cs
@@ -13,7 +13,7 @@ namespace SharperUniverse.Tests.Stubs
         private readonly TestSystem _test;
         private readonly EmptySystem _empty;
 
-        public FooBarSystem(GameRunner game, FooSystem foo, TestSystem test, EmptySystem empty) : base(game)
+        public FooBarSystem(IGameRunner game, FooSystem foo, TestSystem test, EmptySystem empty) : base(game)
         {
             TestSwitch = false;
             _foo = foo;

--- a/SharperUniverse.Tests/Stubs/FooSystem.cs
+++ b/SharperUniverse.Tests/Stubs/FooSystem.cs
@@ -10,7 +10,7 @@ namespace SharperUniverse.Tests.Stubs
 
         private BarSystem _barSystem;
 
-        public FooSystem(GameRunner game, BarSystem barSystem) : base(game)
+        public FooSystem(IGameRunner game, BarSystem barSystem) : base(game)
         {
             TestSwitch = false;
             _barSystem = barSystem;

--- a/SharperUniverse.Tests/Stubs/TestSystem.cs
+++ b/SharperUniverse.Tests/Stubs/TestSystem.cs
@@ -11,7 +11,7 @@ namespace SharperUniverse.Tests.Stubs
         private float _updateTime;
         private readonly EmptySystem _emptySystem;
 
-        public TestSystem(GameRunner game, EmptySystem emptySystem) : base(game)
+        public TestSystem(IGameRunner game, EmptySystem emptySystem) : base(game)
         {
             _prevStates = new Dictionary<TestComponent, bool>();
             ComponentRegistered += OnComponentRegistered;

--- a/SharperUniverse/Core/Builder/GameBuilder.cs
+++ b/SharperUniverse/Core/Builder/GameBuilder.cs
@@ -20,7 +20,7 @@ namespace SharperUniverse.Core.Builder
         /// </summary>
         public GameBuilder()
         {
-        _commandBindings = new Dictionary<string, Type>();
+            _commandBindings = new Dictionary<string, Type>();
             ServerLog.LogInfo($"Game server {Assembly.GetCallingAssembly().GetName().Name} is now building...");
             // Prime our game runner, and add to it as we construct the builder
             _game = new GameRunner();

--- a/SharperUniverse/Core/Builder/SystemBuilder.cs
+++ b/SharperUniverse/Core/Builder/SystemBuilder.cs
@@ -47,8 +47,7 @@ namespace SharperUniverse.Core.Builder
             {
                 foreach (var parameter in systemConstructor.GetParameters())
                 {
-                    if (parameter.ParameterType != typeof(GameRunner) &&
-                        !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(parameter.ParameterType)
+                    if (!typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(parameter.ParameterType)
                         && parameter.ParameterType != typeof(IGameRunner))
                     {
                         // Maybe we want to `break;` here?
@@ -97,11 +96,11 @@ namespace SharperUniverse.Core.Builder
         }
 
         // Local method - recursively called to build dependency graph
-        object ComposeSystem(Type type)
+        private object ComposeSystem(Type type)
         {
             // If we're not GameRunner or a system, then get out of here
             //  We may want to consider throwing InvalidOperationException here?
-            if (type != typeof(GameRunner) && type != typeof(IGameRunner) && !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(type))
+            if (type != typeof(IGameRunner) && !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(type))
             {
                 return null;
             }

--- a/SharperUniverse/Core/Builder/SystemBuilder.cs
+++ b/SharperUniverse/Core/Builder/SystemBuilder.cs
@@ -48,7 +48,8 @@ namespace SharperUniverse.Core.Builder
                 foreach (var parameter in systemConstructor.GetParameters())
                 {
                     if (parameter.ParameterType != typeof(GameRunner) &&
-                        !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(parameter.ParameterType))
+                        !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(parameter.ParameterType)
+                        && parameter.ParameterType != typeof(IGameRunner))
                     {
                         // Maybe we want to `break;` here?
                         //  For now, assume that if it's not a GameRunner or a system, then it's not supported.
@@ -80,21 +81,7 @@ namespace SharperUniverse.Core.Builder
                 //  and instantiating them along the way
                 foreach (var parameter in systemBuilder.GetParameters())
                 {
-                    if (_registeredSystemParameters.TryGetValue(parameter.ParameterType, out var parameterInstance))
-                    {
-                        // We've already registered this type, so simply retrieve its registered instance and use it
-                        systemParameters.Add(parameterInstance);
-                    }
-                    else
-                    {
-                        // This type hasn't been registered yet, so recursively look through its
-                        //  dependencies and grab/register them as needed
-                        var composedSystem = ComposeSystem(parameter.ParameterType);
-                        if (composedSystem != null)
-                        {
-                            systemParameters.Add(composedSystem);
-                        }
-                    }
+                    systemParameters.Add(RegisterParameter(parameter));
                 }
 
                 // Finally, register this top-level system into this builder's graph.
@@ -107,44 +94,60 @@ namespace SharperUniverse.Core.Builder
             ServerLog.LogInfo("Systems attached.");
 
             return new EntityBuilder(_game);
+        }
 
-            // Local method - recursively called to build dependency graph
-            object ComposeSystem(Type type)
+        // Local method - recursively called to build dependency graph
+        object ComposeSystem(Type type)
+        {
+            // If we're not GameRunner or a system, then get out of here
+            //  We may want to consider throwing InvalidOperationException here?
+            if (type != typeof(GameRunner) && type != typeof(IGameRunner) && !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(type))
             {
-                // If we're not GameRunner or a system, then get out of here
-                //  We may want to consider throwing InvalidOperationException here?
-                if (type != typeof(GameRunner) && !typeof(BaseSharperSystem<>).IsSubclassOfRawGeneric(type))
+                return null;
+            }
+
+
+
+            object instance = null;
+
+            // Recursively look through this dependency, registering any new systems we come across
+            //  and re-using systems/gamerunners we've already registered along the way
+            foreach (var ctor in type.GetConstructors())
+            {
+                List<object> systemParameters = new List<object>();
+
+                foreach (var parameter in ctor.GetParameters())
                 {
-                    return null;
+                    systemParameters.Add(RegisterParameter(parameter));
                 }
 
-                object instance = null;
+                // Instantiates this system's constructor, implicitly registering itself to the GameRunner
+                //  and caching off its instance for use as a parent system's constructor parameter
+                instance = ctor.Invoke(systemParameters.ToArray());
+            }
 
-                // Recursively look through this dependency, registering any new systems we come across
-                //  and re-using systems/gamerunners we've already registered along the way
-                foreach (var ctor in type.GetConstructors())
-                {
-                    List<object> systemParameters = new List<object>();
+            _registeredSystemParameters.Add(type, instance);
+            return instance;
+        }
 
-                    foreach (var parameter in ctor.GetParameters())
-                    {
-                        if (_registeredSystemParameters.TryGetValue(parameter.ParameterType, out var parameterInstance))
-                        {
-                            systemParameters.Add(parameterInstance);
-                        }
-                        else
-                        {
-                            systemParameters.Add(ComposeSystem(parameter.ParameterType));
-                        }
-                    }
-
-                    // Instantiates this system's constructor, implicitly registering itself to the GameRunner
-                    //  and caching off its instance for use as a parent system's constructor parameter
-                    instance = ctor.Invoke(systemParameters.ToArray());
-                }
-
-                _registeredSystemParameters.Add(type, instance);
-                return instance;
+        private object RegisterParameter(ParameterInfo parameter)
+        {
+            if (_registeredSystemParameters.TryGetValue(parameter.ParameterType, out var parameterInstance))
+            {
+                // We've already registered this type, so simply retrieve its registered instance and use it
+                return parameterInstance;
+            }
+            else if (parameter.ParameterType == typeof(IGameRunner))
+            {
+                //TryGetValue does not work for Interfaces, and as such here is a hacky work around
+                //FIX THIS RUBY OR SOMEONE PLEASE ~ Love Ron
+                return _game;
+            }
+            else
+            {
+                // This type hasn't been registered yet, so recursively look through its
+                //  dependencies and grab/register them as needed
+                return ComposeSystem(parameter.ParameterType);
             }
         }
     }


### PR DESCRIPTION
Fixed Parameter mismatch due to `TryGetValue` not checking for interface implementations, aka not seeing `GameRunner` as the same as `IGameRunner`, and duplicate code.